### PR TITLE
extendeble export

### DIFF
--- a/src/Mgallegos/LaravelJqgrid/Encoders/JqGridJsonEncoder.php
+++ b/src/Mgallegos/LaravelJqgrid/Encoders/JqGridJsonEncoder.php
@@ -260,6 +260,16 @@ class JqGridJsonEncoder implements RequestedDataInterface {
 
 		if($exporting)
 		{
+			$method_name = 'export_to_'.$postedData['exportFormat'];
+			if(method_exists($Repository, $method_name) )
+			{
+				$Repository->$method_name(array_merge(
+									['rows'=>$rows],
+									['postedData'=>$postedData]
+								      )
+							 );
+			}
+			
 			$this->Excel->create($postedData['name'], function($Excel) use ($rows, $postedData)
 			{
 				foreach (json_decode($postedData['fileProperties'], true) as $key => $value)


### PR DESCRIPTION
Now we can create a method export_to_xls (or other ['exportFormat']) in our implementation RepositoryInterface/EloquentRepositoryAbstract
and describe it to export data process

All data were obtained in an array ['rows', 'postedData']