### PR TITLE
Fix UTF8 JSON encoding bug.

### DIFF
--- a/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingMaxDepthException.php
+++ b/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingMaxDepthException.php
@@ -1,0 +1,11 @@
+<?php namespace Mgallegos\LaravelJqgrid\Exceptions;
+/**
+ * @file
+ * JqGrid JSON Encoder.
+ *
+ * All LaravelJqGrid code is copyright by the original authors and released under the MIT License.
+ * See LICENSE.
+ */
+
+
+class JsonEncodingMaxDepthException extends \Exception {}

--- a/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingStateMismatchException.php
+++ b/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingStateMismatchException.php
@@ -1,0 +1,11 @@
+<?php namespace Mgallegos\LaravelJqgrid\Exceptions;
+/**
+ * @file
+ * JqGrid JSON Encoder.
+ *
+ * All LaravelJqGrid code is copyright by the original authors and released under the MIT License.
+ * See LICENSE.
+ */
+
+
+class JsonEncodingStateMismatchException extends \Exception {}

--- a/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingSyntaxErrorException.php
+++ b/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingSyntaxErrorException.php
@@ -1,0 +1,11 @@
+<?php namespace Mgallegos\LaravelJqgrid\Exceptions;
+/**
+ * @file
+ * JqGrid JSON Encoder.
+ *
+ * All LaravelJqGrid code is copyright by the original authors and released under the MIT License.
+ * See LICENSE.
+ */
+
+
+class JsonEncodingSyntaxErrorException extends \Exception {}

--- a/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingUnexpectedControlCharException.php
+++ b/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingUnexpectedControlCharException.php
@@ -1,0 +1,11 @@
+<?php namespace Mgallegos\LaravelJqgrid\Exceptions;
+/**
+ * @file
+ * JqGrid JSON Encoder.
+ *
+ * All LaravelJqGrid code is copyright by the original authors and released under the MIT License.
+ * See LICENSE.
+ */
+
+
+class JsonEncodingUnexpectedControlCharException extends \Exception {}

--- a/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingUnknownException.php
+++ b/src/Mgallegos/LaravelJqgrid/Exceptions/JsonEncodingUnknownException.php
@@ -1,0 +1,11 @@
+<?php namespace Mgallegos\LaravelJqgrid\Exceptions;
+/**
+ * @file
+ * JqGrid JSON Encoder.
+ *
+ * All LaravelJqGrid code is copyright by the original authors and released under the MIT License.
+ * See LICENSE.
+ */
+
+
+class JsonEncodingUnknownException extends \Exception {}


### PR DESCRIPTION
Fix for #61.
Calls a custom safe_json_encode() function that tries to resolve UTF8 encoding issue or at least throw an exception that can be dealt with from the calling function or program.

Cheers.
/s