### PR TITLE
Fix undeclared variable error.

### DIFF
--- a/src/Mgallegos/LaravelJqgrid/Encoders/JqGridJsonEncoder.php
+++ b/src/Mgallegos/LaravelJqgrid/Encoders/JqGridJsonEncoder.php
@@ -293,7 +293,7 @@ class JqGridJsonEncoder implements RequestedDataInterface {
 
 					$groupHeaders = json_decode($postedData['groupHeaders'], true);
 
-					$columnsPositions = $summaryTypes = $modelLabels = $modelSelectFormattersValues = $modelNumberFormatters = $numericColumns = array();
+					$columnsPositions = $summaryTypes = $modelLabels = $modelSelectFormattersValues = $modelNumberFormatters = $modelDateFormatters = $numericColumns = array();
 
 					$groupFieldName = '';
 


### PR DESCRIPTION
Fix for issue #65, that was causing this exception:
```
Exception message: Undefined variable: modelDateFormatters
In file: /vendor/mgallegos/laravel-jqgrid/src/Mgallegos/LaravelJqgrid/Encoders/JqGridJsonEncoder.php
On line: 450
```